### PR TITLE
feat: add option to fetch cloud-only workout records

### DIFF
--- a/CLOUD-IMPORT-TEST.md
+++ b/CLOUD-IMPORT-TEST.md
@@ -1,0 +1,27 @@
+# Cloud Import Duplicate Check
+
+This guide describes how to verify that importing workout data from the cloud does not introduce duplicate records.
+
+## Manual steps
+1. Open the app in a browser and log in.
+2. Open the developer console (F12) and get the data manager instance:
+   ```javascript
+   const dm = window.workoutDataManager; // or the variable used in your page
+   ```
+3. Check the current number of workout records and store it for later:
+   ```javascript
+   const before = dm.getData('workoutHistory').length;
+   ```
+4. Import from the cloud:
+   ```javascript
+   await dm.importFromCloud();
+   ```
+5. Run the uniqueness check:
+   ```javascript
+   const history = dm.getData('workoutHistory');
+   const keys = new Set(history.map(r => r.id || (r.name + r.date + r.setNumber)));
+   console.log('No duplicates:', keys.size === history.length);
+   ```
+6. Re-run the import command in step 4. The record count should remain the same and the uniqueness check should continue to print `true`.
+
+If all checks pass, cloud imports are not creating duplicate workout records.

--- a/shared/cloud-data-manager-v12.js
+++ b/shared/cloud-data-manager-v12.js
@@ -161,10 +161,10 @@ class CloudDataManager {
     }
     
     // 운동 기록 조회
-    async getWorkoutRecords() {
-        // 로그인되지 않았거나 오프라인인 경우 로컬 데이터 반환
+    async getWorkoutRecords(includeLocal = true) {
+        // 로그인되지 않았거나 오프라인인 경우
         if (!this.isOnline || !this.db || !this.currentUser) {
-            return this.localDataManager?.getWorkoutRecords() || [];
+            return includeLocal ? (this.localDataManager?.getWorkoutRecords() || []) : [];
         }
         
         try {
@@ -188,15 +188,16 @@ class CloudDataManager {
             });
             
             console.log('☁️ 클라우드에서 운동 기록 조회:', records.length + '개');
-            
-            // 로컬과 클라우드 데이터 병합
-            const localRecords = this.localDataManager?.getWorkoutRecords() || [];
-            const mergedRecords = this.mergeRecords(localRecords, records);
-            
-            return mergedRecords;
+
+            // 로컬과 클라우드 데이터 병합 여부
+            if (includeLocal) {
+                const localRecords = this.localDataManager?.getWorkoutRecords() || [];
+                return this.mergeRecords(localRecords, records);
+            }
+            return records;
         } catch (error) {
             console.error('❌ 클라우드 조회 실패 - 로컬 데이터 사용:', error);
-            return this.localDataManager?.getWorkoutRecords() || [];
+            return includeLocal ? (this.localDataManager?.getWorkoutRecords() || []) : [];
         }
     }
     

--- a/shared/data-manager.js
+++ b/shared/data-manager.js
@@ -18,8 +18,8 @@ class WorkoutDataManager {
     async importFromCloud(maxRecords = 500) {
         if (!this.cloudDataManager || !this.cloudDataManager.currentUser) return;
         try {
-            // Import workout records
-            const cloudRecords = await this.cloudDataManager.getWorkoutRecords();
+            // Import workout records (cloud only)
+            const cloudRecords = await this.cloudDataManager.getWorkoutRecords(false);
             if (Array.isArray(cloudRecords) && cloudRecords.length) {
                 const history = this.getData('workoutHistory') || [];
                 const byKey = new Map();


### PR DESCRIPTION
## Summary
- allow CloudDataManager.getWorkoutRecords to skip merging local records
- pull only cloud workout records during imports
- document manual steps to verify no duplicates after cloud import

## Testing
- `node --check shared/cloud-data-manager-v12.js`
- `node --check shared/data-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68b010832b108326a88be2bf8fa6973d